### PR TITLE
Add ability to control the order in which styles are applied to entities

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+[
+  import_deps: [],
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
+  subdirectories: []
+]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,50 @@ You can `use Draft` in your module, and then extend it with custom
 
   MyCustomDraft.to_html(input)
 ```
+
+You can pass a third variable for context that your custom processors can hook 
+into.
+
+```
+  # capture the relevant context vars in your custom processors
+  defmodule MyCustomDraft do
+    use Draft
+
+
+    def process_block(%{"type" => "atomic",
+                        "text" => "",
+                        "key" => _,
+                        "data" => %{"type" => "image", "url" => url},
+                        "depth" => _,
+                        "entityRanges" => _,
+                        "inlineStyleRanges" => _}, [user: user]) do
+      "<img src='#{url}' alt='#{user.name}' />"
+    end
+  end
+
+  # somewhere else you can pass any number of vars as the third argument
+
+  user = %{name: "Pablo"}
+
+  input = %{
+    "entityMap"=>%{},
+    "blocks"=>[
+      %{"key"=>"9d21d",
+        "text"=>"Hello",
+        "type"=>"header-one",
+        "depth"=>0,
+        "inlineStyleRanges"=>[],
+        "entityRanges"=>[],
+        "data"=>%{}}
+      %{"key"=>"d12d9",
+        "text"=>"",
+        "type"=>"atomic",
+        "depth"=>0,
+        "inlineStyleRanges"=>[],
+        "entityRanges"=>[],
+        "data"=>%{
+          "type"=>"atomic",
+          "url"=>"https://uploads.digitalonboarding.com/do_logo_long.png"}}]}
+
+  MyCustomDraft.to_html(input, user: user)
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Draft is a module that parses a JSON representation of [Draft.js](https://facebo
 You can `use Draft` in your module, and then extend it with custom 
 `process_block`, `process_style`, and `process_entity` function signatures
 
-```
+```elixir
   # define your draft module
   defmodule MyCustomDraft do
     use Draft
@@ -51,7 +51,7 @@ You can `use Draft` in your module, and then extend it with custom
 You can pass a third variable for context that your custom processors can hook 
 into.
 
-```
+```elixir
   # capture the relevant context vars in your custom processors
   defmodule MyCustomDraft do
     use Draft

--- a/README.md
+++ b/README.md
@@ -2,4 +2,48 @@
 
 Draft is a module that parses a JSON representation of [Draft.js](https://facebook.github.io/draft-js/) `convertToRaw` output and turns it into HTML.
 
-It is very work in progress.
+## Usage
+
+You can `use Draft` in your module, and then extend it with custom 
+`process_block`, `process_style`, and `process_entity` function signatures
+
+```
+  # define your draft module
+  defmodule MyCustomDraft do
+    use Draft
+
+
+    def process_block(%{"type" => "atomic",
+                        "text" => "",
+                        "key" => _,
+                        "data" => %{"type" => "image", "url" => url},
+                        "depth" => _,
+                        "entityRanges" => _,
+                        "inlineStyleRanges" => _}, _) do
+      "<img src='#{url}' />"
+    end
+  end
+
+  # somewhere else you can pass your custom draft map to `to_html`
+  input = %{
+    "entityMap"=>%{},
+    "blocks"=>[
+      %{"key"=>"9d21d",
+        "text"=>"Hello",
+        "type"=>"header-one",
+        "depth"=>0,
+        "inlineStyleRanges"=>[],
+        "entityRanges"=>[],
+        "data"=>%{}}
+      %{"key"=>"d12d9",
+        "text"=>"",
+        "type"=>"atomic",
+        "depth"=>0,
+        "inlineStyleRanges"=>[],
+        "entityRanges"=>[],
+        "data"=>%{
+          "type"=>"atomic",
+          "url"=>"https://uploads.digitalonboarding.com/do_logo_long.png"}}]}
+
+  MyCustomDraft.to_html(input)
+```

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -23,7 +23,7 @@ defmodule Draft do
         |> Map.get("blocks")
         |> Enum.reduce([], &group_list_items/2)
         |> Enum.map(&process_block(&1, entity_map, context))
-        |> Enum.join("\n")
+        |> Enum.join("")
       end
 
       @doc """

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -37,7 +37,7 @@ defmodule Draft do
       [%{"type"=>"unordered-list","data"=>%{"children"=>[%{"key"=>"1","text"=>"Hello","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}}]
       """
 
-      defp group_list_items(block, acc) do
+      def group_list_items(block, acc) do
         case block["type"] do
           type when type in ["unordered-list-item", "ordered-list-item"] ->
             list_type = String.replace(block["type"], "-item", "")

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -16,12 +16,12 @@ defmodule Draft do
 
       use Draft.Block
 
-      def to_html(input) do
+      def to_html(input, context \\ []) do
         entity_map = Map.get(input, "entityMap")
 
         input
         |> Map.get("blocks")
-        |> Enum.map(&(process_block(&1, entity_map)))
+        |> Enum.map(&(process_block(&1, entity_map, context)))
         |> Enum.join("")
       end
     end

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -12,9 +12,11 @@ defmodule Draft do
       "<p>Hello</p>"
   """
   def to_html(input) do
+    entity_map = Map.get(input, "entityMap")
+
     input
       |> Map.get("blocks")
-      |> Enum.map(&Draft.Block.to_html/1)
+      |> Enum.map(&(Draft.Block.to_html(&1, entity_map)))
       |> Enum.join("")
   end
 end

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -21,8 +21,45 @@ defmodule Draft do
 
         input
         |> Map.get("blocks")
+        |> Enum.reduce([], group_list_items())
         |> Enum.map(&(process_block(&1, entity_map, context)))
         |> Enum.join("")
+      end
+
+      @doc """
+      Groups pertinent block types (i.e. ordered and unordered lists), allowing us to define
+      `process_block` signatures for both the wrapper component and their children (see
+      process_block signature for `unordered-list`, it's responsible for rendering its children)
+
+      ## Examples
+      iex> blocks = [%{"key"=>"1","text"=>"Hello","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]
+      iex> Enum.reduce(blocks, [], group_list_items())
+      [%{"type"=>"unordered-list","data"=>%{"children"=>[%{"key"=>"1","text"=>"Hello","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}}]
+      """
+
+      defp group_list_items(block, acc) do
+        case block["type"] do
+          type when type in ["unordered-list-item", "ordered-list-item"] ->
+            list_type = String.replace(block["type"], "-item", "")
+
+            with {last_item, all_but_last_item} when not is_nil(last_item) <- List.pop_at(acc, length(acc) - 1),
+                  type when type == list_type <- Map.get(last_item, "type")
+                  #FIXME: this ignores depth
+              do
+                all_but_last_item ++ [add_block_item_to_previous_list(last_item, block)]
+              else
+                _ -> acc ++ [%{"type" => list_type,
+                              "data" => %{"children" => [block]}}]
+            end
+          _ -> acc ++ [block]
+        end
+      end
+
+      defp add_block_item_to_previous_list(previous_list, block) do
+        updated_children = previous_list["data"]["children"] ++ [block]
+        updated_data = Map.put(previous_list["data"], "children", updated_children)
+
+        Map.put(previous_list, "data", updated_data)
       end
     end
   end

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -21,7 +21,7 @@ defmodule Draft do
 
         input
         |> Map.get("blocks")
-        |> Enum.reduce([], group_list_items())
+        |> Enum.reduce([], &group_list_items/2)
         |> Enum.map(&(process_block(&1, entity_map, context)))
         |> Enum.join("")
       end

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -4,31 +4,16 @@ defmodule Draft do
   """
 
   @doc """
-  Parses the given DraftJS input and returns the blocks as a list of
-  maps.
-
-  ## Examples
-      iex> draft = ~s({"entityMap":{},"blocks":[{"key":"1","text":"Hello","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
-      iex> Draft.blocks draft
-      [%{"key" => "1", "text" => "Hello", "type" => "unstyled",
-         "depth" => 0,  "inlineStyleRanges" => [], "entityRanges" => [],
-         "data" => %{}}]
-  """
-  def blocks(input) do
-    Poison.Parser.parse!(input)["blocks"]
-  end
-
-  @doc """
   Renders the given DraftJS input as html.
 
   ## Examples
-      iex> draft = ~s({"entityMap":{},"blocks":[{"key":"1","text":"Hello","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+      iex> draft = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"1","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
       iex> Draft.to_html draft
       "<p>Hello</p>"
   """
   def to_html(input) do
     input
-      |> blocks
+      |> Map.get("blocks")
       |> Enum.map(&Draft.Block.to_html/1)
       |> Enum.join("")
   end

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -23,7 +23,7 @@ defmodule Draft do
         |> Map.get("blocks")
         |> Enum.reduce([], &group_list_items/2)
         |> Enum.map(&process_block(&1, entity_map, context))
-        |> Enum.join("")
+        |> Enum.join("\n")
       end
 
       @doc """

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -22,7 +22,7 @@ defmodule Draft do
         input
         |> Map.get("blocks")
         |> Enum.reduce([], &group_list_items/2)
-        |> Enum.map(&(process_block(&1, entity_map, context)))
+        |> Enum.map(&process_block(&1, entity_map, context))
         |> Enum.join("")
       end
 
@@ -42,16 +42,17 @@ defmodule Draft do
           type when type in ["unordered-list-item", "ordered-list-item"] ->
             list_type = String.replace(block["type"], "-item", "")
 
-            with {last_item, all_but_last_item} when not is_nil(last_item) <- List.pop_at(acc, length(acc) - 1),
-                  type when type == list_type <- Map.get(last_item, "type")
-                  #FIXME: this ignores depth
-              do
-                all_but_last_item ++ [add_block_item_to_previous_list(last_item, block)]
-              else
-                _ -> acc ++ [%{"type" => list_type,
-                              "data" => %{"children" => [block]}}]
+            # FIXME: this ignores depth
+            with {last_item, all_but_last_item} when not is_nil(last_item) <-
+                   List.pop_at(acc, length(acc) - 1),
+                 type when type == list_type <- Map.get(last_item, "type") do
+              all_but_last_item ++ [add_block_item_to_previous_list(last_item, block)]
+            else
+              _ -> acc ++ [%{"type" => list_type, "data" => %{"children" => [block]}}]
             end
-          _ -> acc ++ [block]
+
+          _ ->
+            acc ++ [block]
         end
       end
 

--- a/lib/draft.ex
+++ b/lib/draft.ex
@@ -1,22 +1,29 @@
 defmodule Draft do
-  @moduledoc """
-  Provides functions for parsing DraftJS content.
-  """
+  defmacro __using__(_) do
+    quote do
+      @moduledoc """
+      Provides functions for parsing DraftJS content.
+      """
 
-  @doc """
-  Renders the given DraftJS input as html.
+      @doc """
+      Renders the given DraftJS input as html.
 
-  ## Examples
+      ## Examples
       iex> draft = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"1","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
       iex> Draft.to_html draft
       "<p>Hello</p>"
-  """
-  def to_html(input) do
-    entity_map = Map.get(input, "entityMap")
+      """
 
-    input
-      |> Map.get("blocks")
-      |> Enum.map(&(Draft.Block.to_html(&1, entity_map)))
-      |> Enum.join("")
+      use Draft.Block
+
+      def to_html(input) do
+        entity_map = Map.get(input, "entityMap")
+
+        input
+        |> Map.get("blocks")
+        |> Enum.map(&(process_block(&1, entity_map)))
+        |> Enum.join("")
+      end
+    end
   end
 end

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -33,7 +33,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<ul>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ul>"
+        "<ul>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("\n")}</ul>"
       end
 
       def process_block(
@@ -41,7 +41,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<ol>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ol>"
+        "<ol>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("\n")}</ol>"
       end
 
       def process_block(

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -51,6 +51,40 @@ defmodule Draft.Block do
         "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</p>"
       end
 
+      def process_block(%{"type" => "unordered-list",
+                          "data" => %{"children" => children}},
+        entity_map, context) do
+        "<ul>#{Enum.map(children, &(process_block(&1, entity_map, context))) |> Enum.join("")}</ul>"
+      end
+
+      def process_block(%{"type" => "ordered-list",
+                          "data" => %{"children" => children}},
+        entity_map, context) do
+        "<ol>#{Enum.map(children, &(process_block(&1, entity_map, context))) |> Enum.join("")}</ol>"
+      end
+
+      def process_block(%{"type" => "ordered-list-item",
+                          "text" => text,
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => entity_ranges,
+                          "inlineStyleRanges" => inline_style_ranges},
+        entity_map, context) do
+        "<li>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</li>"
+      end
+
+      def process_block(%{"type" => "unordered-list-item",
+                          "text" => text,
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => entity_ranges,
+                          "inlineStyleRanges" => inline_style_ranges},
+        entity_map, context) do
+        "<li>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</li>"
+      end
+
       def header_tags do
         %{
           "one"   => "h1",

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -24,9 +24,9 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map, _) do
+                        entity_map, context) do
         tag = header_tags[header]
-        "<#{tag}>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</#{tag}>"
+        "<#{tag}>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</#{tag}>"
       end
 
       def process_block(%{"type" => "blockquote",
@@ -36,8 +36,8 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map, _) do
-        "<blockquote>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</blockquote>"
+                        entity_map, context) do
+        "<blockquote>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</blockquote>"
       end
 
       def process_block(%{"type" => "unstyled",
@@ -47,8 +47,8 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map, _) do
-        "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</p>"
+                        entity_map, context) do
+        "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</p>"
       end
 
       def header_tags do

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -11,53 +11,59 @@ defmodule Draft.Block do
         "<br>"
       end
 
-      def process_block(%{"type" => "header-" <> header,
-                          "text" => text} = block,
-                        entity_map, context) do
+      def process_block(
+            %{"type" => "header-" <> header, "text" => text} = block,
+            entity_map,
+            context
+          ) do
         tag = header_tags[header]
         "<#{tag}>#{apply_ranges(block, entity_map, context)}</#{tag}>"
       end
 
-      def process_block(%{"type" => "blockquote",
-                          "text" => text} = block,
-                        entity_map, context) do
+      def process_block(%{"type" => "blockquote", "text" => text} = block, entity_map, context) do
         "<blockquote>#{apply_ranges(block, entity_map, context)}</blockquote>"
       end
 
-      def process_block(%{"type" => "unstyled",
-                          "text" => text} = block,
-                        entity_map, context) do
+      def process_block(%{"type" => "unstyled", "text" => text} = block, entity_map, context) do
         "<p>#{apply_ranges(block, entity_map, context)}</p>"
       end
 
-      def process_block(%{"type" => "unordered-list",
-                          "data" => %{"children" => children}},
-        entity_map, context) do
-        "<ul>#{Enum.map(children, &(process_block(&1, entity_map, context))) |> Enum.join("")}</ul>"
+      def process_block(
+            %{"type" => "unordered-list", "data" => %{"children" => children}},
+            entity_map,
+            context
+          ) do
+        "<ul>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ul>"
       end
 
-      def process_block(%{"type" => "ordered-list",
-                          "data" => %{"children" => children}},
-        entity_map, context) do
-        "<ol>#{Enum.map(children, &(process_block(&1, entity_map, context))) |> Enum.join("")}</ol>"
+      def process_block(
+            %{"type" => "ordered-list", "data" => %{"children" => children}},
+            entity_map,
+            context
+          ) do
+        "<ol>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ol>"
       end
 
-      def process_block(%{"type" => "ordered-list-item",
-                          "text" => text} = block,
-        entity_map, context) do
+      def process_block(
+            %{"type" => "ordered-list-item", "text" => text} = block,
+            entity_map,
+            context
+          ) do
         "<li>#{apply_ranges(block, entity_map, context)}</li>"
       end
 
-      def process_block(%{"type" => "unordered-list-item",
-                          "text" => text} = block,
-        entity_map, context) do
+      def process_block(
+            %{"type" => "unordered-list-item", "text" => text} = block,
+            entity_map,
+            context
+          ) do
         "<li>#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def header_tags do
         %{
-          "one"   => "h1",
-          "two"   => "h2",
+          "one" => "h1",
+          "two" => "h2",
           "three" => "h3"
         }
       end

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -16,7 +16,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        tag = header_tags[header]
+        tag = header_tags()[header]
         "<#{tag}>#{apply_ranges(block, entity_map, context)}</#{tag}>"
       end
 

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -49,7 +49,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<li>#{apply_ranges(block, entity_map, context)}</li>"
+        "<li style=\"mso-special-format:numbullet;\">#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def process_block(
@@ -57,7 +57,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<li>#{apply_ranges(block, entity_map, context)}</li>"
+        "<li style=\"mso-special-format:bullet;\">#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def header_tags do

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -7,48 +7,27 @@ defmodule Draft.Block do
 
       use Draft.Ranges
 
-      def process_block(%{"type" => "unstyled",
-                          "text" => "",
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => _,
-                          "inlineStyleRanges" => _}, _, _) do
+      def process_block(%{"type" => "unstyled", "text" => ""}, _, _) do
         "<br>"
       end
 
       def process_block(%{"type" => "header-" <> header,
-                          "text" => text,
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => entity_ranges,
-                          "inlineStyleRanges" => inline_style_ranges},
+                          "text" => text} = block,
                         entity_map, context) do
         tag = header_tags[header]
-        "<#{tag}>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</#{tag}>"
+        "<#{tag}>#{apply_ranges(block, entity_map, context)}</#{tag}>"
       end
 
       def process_block(%{"type" => "blockquote",
-                          "text" => text,
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => entity_ranges,
-                          "inlineStyleRanges" => inline_style_ranges},
+                          "text" => text} = block,
                         entity_map, context) do
-        "<blockquote>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</blockquote>"
+        "<blockquote>#{apply_ranges(block, entity_map, context)}</blockquote>"
       end
 
       def process_block(%{"type" => "unstyled",
-                          "text" => text,
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => entity_ranges,
-                          "inlineStyleRanges" => inline_style_ranges},
+                          "text" => text} = block,
                         entity_map, context) do
-        "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</p>"
+        "<p>#{apply_ranges(block, entity_map, context)}</p>"
       end
 
       def process_block(%{"type" => "unordered-list",
@@ -64,25 +43,15 @@ defmodule Draft.Block do
       end
 
       def process_block(%{"type" => "ordered-list-item",
-                          "text" => text,
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => entity_ranges,
-                          "inlineStyleRanges" => inline_style_ranges},
+                          "text" => text} = block,
         entity_map, context) do
-        "<li>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</li>"
+        "<li>#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def process_block(%{"type" => "unordered-list-item",
-                          "text" => text,
-                          "key" => _,
-                          "data" => _,
-                          "depth" => _,
-                          "entityRanges" => entity_ranges,
-                          "inlineStyleRanges" => inline_style_ranges},
+                          "text" => text} = block,
         entity_map, context) do
-        "<li>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context)}</li>"
+        "<li>#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def header_tags do

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -64,7 +64,10 @@ defmodule Draft.Block do
         %{
           "one" => "h1",
           "two" => "h2",
-          "three" => "h3"
+          "three" => "h3",
+          "four" => "h4",
+          "five" => "h5",
+          "six" => "h6"
         }
       end
     end

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -13,7 +13,7 @@ defmodule Draft.Block do
                           "data" => _,
                           "depth" => _,
                           "entityRanges" => _,
-                          "inlineStyleRanges" => _}, _) do
+                          "inlineStyleRanges" => _}, _, _) do
         "<br>"
       end
 
@@ -24,7 +24,7 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map) do
+                        entity_map, _) do
         tag = header_tags[header]
         "<#{tag}>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</#{tag}>"
       end
@@ -36,7 +36,7 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map) do
+                        entity_map, _) do
         "<blockquote>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</blockquote>"
       end
 
@@ -47,7 +47,7 @@ defmodule Draft.Block do
                           "depth" => _,
                           "entityRanges" => entity_ranges,
                           "inlineStyleRanges" => inline_style_ranges},
-                        entity_map) do
+                        entity_map, _) do
         "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</p>"
       end
 

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -1,74 +1,63 @@
 defmodule Draft.Block do
-  @moduledoc """
-  Converts a single DraftJS block to html.
-  """
+  defmacro __using__(_) do
+    quote do
+      @moduledoc """
+      Converts a single DraftJS block to html.
+      """
 
-  alias Draft.Ranges
+      use Draft.Ranges
 
-  @doc """
-  Renders the given DraftJS input as html.
+      def process_block(%{"type" => "unstyled",
+                          "text" => "",
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => _,
+                          "inlineStyleRanges" => _}, _) do
+        "<br>"
+      end
 
-  ## Examples
-      iex> entity_map = %{}
-      iex> block = %{"key" => "1", "text" => "Hello", "type" => "unstyled",
-      ...>   "depth" => 0,  "inlineStyleRanges" => [], "entityRanges" => [],
-      ...>   "data" => %{}}
-      iex> Draft.Block.to_html block, entity_map
-      "<p>Hello</p>"
-  """
-  def to_html(block, entity_map) do
-    process_block(block, entity_map)
-  end
+      def process_block(%{"type" => "header-" <> header,
+                          "text" => text,
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => entity_ranges,
+                          "inlineStyleRanges" => inline_style_ranges},
+                        entity_map) do
+        tag = header_tags[header]
+        "<#{tag}>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</#{tag}>"
+      end
 
-  defp process_block(%{"type" => "unstyled",
-                      "text" => "",
-                      "key" => _,
-                      "data" => _,
-                      "depth" => _,
-                      "entityRanges" => _,
-                      "inlineStyleRanges" => _}, _) do
-    "<br>"
-  end
+      def process_block(%{"type" => "blockquote",
+                          "text" => text,
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => entity_ranges,
+                          "inlineStyleRanges" => inline_style_ranges},
+                        entity_map) do
+        "<blockquote>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</blockquote>"
+      end
 
-  defp process_block(%{"type" => "header-" <> header,
-                      "text" => text,
-                      "key" => _,
-                      "data" => _,
-                      "depth" => _,
-                      "entityRanges" => entity_ranges,
-                      "inlineStyleRanges" => inline_style_ranges},
-                     entity_map) do
-    tag = header_tags[header]
-    "<#{tag}>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</#{tag}>"
-  end
+      def process_block(%{"type" => "unstyled",
+                          "text" => text,
+                          "key" => _,
+                          "data" => _,
+                          "depth" => _,
+                          "entityRanges" => entity_ranges,
+                          "inlineStyleRanges" => inline_style_ranges},
+                        entity_map) do
+        "<p>#{apply_ranges(text, inline_style_ranges, entity_ranges, entity_map)}</p>"
+      end
 
-  defp process_block(%{"type" => "blockquote",
-                      "text" => text,
-                      "key" => _,
-                      "data" => _,
-                      "depth" => _,
-                      "entityRanges" => entity_ranges,
-                      "inlineStyleRanges" => inline_style_ranges},
-                     entity_map) do
-    "<blockquote>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</blockquote>"
-  end
-
-  defp process_block(%{"type" => "unstyled",
-                      "text" => text,
-                      "key" => _,
-                      "data" => _,
-                      "depth" => _,
-                      "entityRanges" => entity_ranges,
-                      "inlineStyleRanges" => inline_style_ranges},
-                     entity_map) do
-    "<p>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</p>"
-  end
-
-  defp header_tags do
-    %{
-      "one"   => "h1",
-      "two"   => "h2",
-      "three" => "h3"
-    }
+      def header_tags do
+        %{
+          "one"   => "h1",
+          "two"   => "h2",
+          "three" => "h3"
+        }
+      end
+    end
   end
 end

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -3,18 +3,21 @@ defmodule Draft.Block do
   Converts a single DraftJS block to html.
   """
 
+  alias Draft.Ranges
+
   @doc """
   Renders the given DraftJS input as html.
 
   ## Examples
+      iex> entity_map = %{}
       iex> block = %{"key" => "1", "text" => "Hello", "type" => "unstyled",
       ...>   "depth" => 0,  "inlineStyleRanges" => [], "entityRanges" => [],
       ...>   "data" => %{}}
-      iex> Draft.Block.to_html block
+      iex> Draft.Block.to_html block, entity_map
       "<p>Hello</p>"
   """
-  def to_html(block) do
-    process_block(block)
+  def to_html(block, entity_map) do
+    process_block(block, entity_map)
   end
 
   defp process_block(%{"type" => "unstyled",
@@ -23,7 +26,7 @@ defmodule Draft.Block do
                       "data" => _,
                       "depth" => _,
                       "entityRanges" => _,
-                      "inlineStyleRanges" => _}) do
+                      "inlineStyleRanges" => _}, _) do
     "<br>"
   end
 
@@ -32,10 +35,11 @@ defmodule Draft.Block do
                       "key" => _,
                       "data" => _,
                       "depth" => _,
-                      "entityRanges" => _,
-                      "inlineStyleRanges" => _}) do
+                      "entityRanges" => entity_ranges,
+                      "inlineStyleRanges" => inline_style_ranges},
+                     entity_map) do
     tag = header_tags[header]
-    "<#{tag}>#{text}</#{tag}>"
+    "<#{tag}>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</#{tag}>"
   end
 
   defp process_block(%{"type" => "blockquote",
@@ -43,9 +47,10 @@ defmodule Draft.Block do
                       "key" => _,
                       "data" => _,
                       "depth" => _,
-                      "entityRanges" => _,
-                      "inlineStyleRanges" => _}) do
-    "<blockquote>#{text}</blockquote>"
+                      "entityRanges" => entity_ranges,
+                      "inlineStyleRanges" => inline_style_ranges},
+                     entity_map) do
+    "<blockquote>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</blockquote>"
   end
 
   defp process_block(%{"type" => "unstyled",
@@ -53,9 +58,10 @@ defmodule Draft.Block do
                       "key" => _,
                       "data" => _,
                       "depth" => _,
-                      "entityRanges" => _,
-                      "inlineStyleRanges" => _}) do
-    "<p>#{text}</p>"
+                      "entityRanges" => entity_ranges,
+                      "inlineStyleRanges" => inline_style_ranges},
+                     entity_map) do
+    "<p>#{Ranges.apply(text, inline_style_ranges, entity_ranges, entity_map)}</p>"
   end
 
   defp header_tags do

--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -33,7 +33,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<ul>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("\n")}</ul>"
+        "<ul>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ul>"
       end
 
       def process_block(
@@ -41,7 +41,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<ol>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("\n")}</ol>"
+        "<ol>#{Enum.map(children, &process_block(&1, entity_map, context)) |> Enum.join("")}</ol>"
       end
 
       def process_block(

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -15,9 +15,10 @@ defmodule Draft.Ranges do
         |> DraftTree.process_tree(fn text, styles, key ->
           cond do
             !is_nil(styles) ->
-              css = styles
-              |> Enum.map(fn style -> process_style(style, context) end)
-              |> Enum.join(" ")
+              css =
+                styles
+                |> Enum.map(fn style -> process_style(style, context) end)
+                |> Enum.join(" ")
 
               "<span style=\"#{css}\">#{text}</span>"
 
@@ -38,7 +39,11 @@ defmodule Draft.Ranges do
         "font-style: italic;"
       end
 
-      def process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}, text, _) do
+      def process_entity(
+            %{"type" => "LINK", "mutability" => "MUTABLE", "data" => %{"url" => url}},
+            text,
+            _
+          ) do
         "<a href=\"#{url}\">#{text}</a>"
       end
 
@@ -46,9 +51,7 @@ defmodule Draft.Ranges do
         ranges
         |> Enum.group_by(fn range -> {range["offset"], range["length"]} end)
         |> Enum.map(fn {{offset, length}, ranges} ->
-          %{"offset" => offset,
-            "length" => length,
-            "styles" => ranges |> Enum.map(&(&1["style"]))}
+          %{"offset" => offset, "length" => length, "styles" => ranges |> Enum.map(& &1["style"])}
         end)
       end
 
@@ -64,13 +67,19 @@ defmodule Draft.Ranges do
           |> Enum.reduce([style_range], fn point, acc ->
             {already_split, [main]} = Enum.split(acc, length(acc) - 1)
 
-            already_split ++ [
-              %{"style" => style_range["style"],
-                "offset" => main["offset"],
-                "length" => point - main["offset"]},
-              %{"style" => style_range["style"],
-                "offset" => point,
-                "length" => main["length"] - (point - main["offset"])}]
+            already_split ++
+              [
+                %{
+                  "style" => style_range["style"],
+                  "offset" => main["offset"],
+                  "length" => point - main["offset"]
+                },
+                %{
+                  "style" => style_range["style"],
+                  "offset" => point,
+                  "length" => main["length"] - (point - main["offset"])
+                }
+              ]
           end)
         end)
         |> List.flatten()
@@ -82,8 +91,10 @@ defmodule Draft.Ranges do
           cond do
             range1["offset"] != range2["offset"] ->
               range1["offset"] < range2["offset"]
+
             range1["length"] != range2["length"] ->
               range1["length"] >= range2["length"]
+
             true ->
               is_nil(range2["styles"])
           end
@@ -94,8 +105,8 @@ defmodule Draft.Ranges do
         Enum.reduce(ranges, [], fn range, acc ->
           acc ++ [range["offset"], range["offset"] + range["length"]]
         end)
-        |> Enum.uniq
-        |> Enum.sort
+        |> Enum.uniq()
+        |> Enum.sort()
       end
     end
   end

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -58,7 +58,7 @@ defmodule Draft.Ranges do
       @doc """
       Cuts up multiple potentially overlapping ranges into more mutually exclusive ranges
       """
-      defp divvy_style_ranges(style_ranges, entity_ranges) do
+      def divvy_style_ranges(style_ranges, entity_ranges) do
         Enum.map(style_ranges, fn style_range ->
           ranges_to_points(entity_ranges ++ style_ranges)
           |> Enum.filter(fn point ->

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -1,109 +1,113 @@
 defmodule Draft.Ranges do
-  @moduledoc """
-  Provides functions for adding inline style ranges and entity ranges
-  """
+  defmacro __using__(_) do
+    quote do
+      @moduledoc """
+      Provides functions for adding inline style ranges and entity ranges
+      """
 
-  def apply(text, inline_style_ranges, entity_ranges, entity_map) do
-    inline_style_ranges ++ entity_ranges
-    |> consolidate_ranges()
-    |> Enum.reduce(text, fn {start, finish}, acc ->
-      {style_opening_tag, style_closing_tag} =
-        case get_styles_for_range(start, finish, inline_style_ranges) do
-          "" -> {"", ""}
-          styles -> {"<span style=\"#{styles}\">", "</span>"}
-        end
-      entity_opening_tags = get_entity_opening_tags_for_start(start, entity_ranges, entity_map)
-      entity_closing_tags = get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map)
-      opening_tags = "#{entity_opening_tags}#{style_opening_tag}"
-      closing_tags = "#{style_closing_tag}#{entity_closing_tags}"
+      def apply_ranges(text, inline_style_ranges, entity_ranges, entity_map) do
+        inline_style_ranges ++ entity_ranges
+        |> consolidate_ranges()
+        |> Enum.reduce(text, fn {start, finish}, acc ->
+          {style_opening_tag, style_closing_tag} =
+            case get_styles_for_range(start, finish, inline_style_ranges) do
+              "" -> {"", ""}
+              styles -> {"<span style=\"#{styles}\">", "</span>"}
+            end
+          entity_opening_tags = get_entity_opening_tags_for_start(start, entity_ranges, entity_map)
+          entity_closing_tags = get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map)
+          opening_tags = "#{entity_opening_tags}#{style_opening_tag}"
+          closing_tags = "#{style_closing_tag}#{entity_closing_tags}"
 
-      adjusted_start = start + String.length(acc) - String.length(text)
-      adjusted_finish = finish + String.length(acc) - String.length(text)
+          adjusted_start = start + String.length(acc) - String.length(text)
+          adjusted_finish = finish + String.length(acc) - String.length(text)
 
-      acc
-      |> String.split_at(adjusted_finish)
-      |> Tuple.to_list
-      |> Enum.join(closing_tags)
-      |> String.split_at(adjusted_start)
-      |> Tuple.to_list
-      |> Enum.join(opening_tags)
-    end)
-  end
-
-  defp process_style("BOLD") do
-    "font-weight: bold;"
-  end
-
-  defp process_style("ITALIC") do
-    "font-style: italic;"
-  end
-
-  defp process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}) do
-    {"<a href=\"#{url}\">", "</a>"}
-  end
-
-  defp get_styles_for_range(start, finish, inline_style_ranges) do
-    inline_style_ranges
-    |> Enum.filter(fn range -> is_in_range(range, start, finish) end)
-    |> Enum.map(fn range -> process_style(range["style"]) end)
-    |> Enum.join(" ")
-  end
-
-  defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map) do
-    entity_ranges
-    |> Enum.filter(fn range -> range["offset"] === start end)
-    |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(0) end)
-  end
-
-  defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map) do
-    entity_ranges
-    |> Enum.filter(fn range -> range["offset"] + range["length"] === finish end)
-    |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(1) end)
-    |> Enum.reverse()
-  end
-
-  defp is_in_range(range, start, finish) do
-    range_start = range["offset"]
-    range_finish = range["offset"] + range["length"]
-
-    start >= range_start && finish <= range_finish
-  end
-
-  @doc """
-  Takes multiple potentially overlapping ranges and breaks them into other mutually exclusive
-  ranges, so we can take each mini-range and add the specified, potentially multiple, styles
-  and entities to each mini-range
-
-  ## Examples
-      iex> ranges = [
-        %{"offset" => 0, "length" => 4, "style" => "ITALIC"},
-        %{"offset" => 4, "length" => 4, "style" => "BOLD"},
-        %{"offset" => 2, "length" => 3, "key" => 0}]
-      iex> consolidate_ranges(ranges)
-      [{0, 2}, {2, 4}, {4, 5}, {5, 8}]
-  """
-  defp consolidate_ranges(ranges) do
-    ranges
-    |> ranges_to_points()
-    |> points_to_ranges()
-  end
-
-  defp points_to_ranges(points) do
-    points
-    |> Enum.with_index
-    |> Enum.reduce([], fn {point, index}, acc ->
-      case Enum.at(points, index + 1) do
-        nil -> acc
-        next -> acc ++ [{point, next}]
+          acc
+          |> String.split_at(adjusted_finish)
+          |> Tuple.to_list
+          |> Enum.join(closing_tags)
+          |> String.split_at(adjusted_start)
+          |> Tuple.to_list
+          |> Enum.join(opening_tags)
+        end)
       end
-    end)
-  end
 
-  defp ranges_to_points(ranges) do
-    Enum.reduce(ranges, [], fn range, acc ->
-      acc ++ [range["offset"], range["offset"] + range["length"]]
-    end)
-    |> Enum.uniq
-    |> Enum.sort
+      def process_style("BOLD") do
+        "font-weight: bold;"
+      end
+
+      def process_style("ITALIC") do
+        "font-style: italic;"
+      end
+
+      def process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}) do
+        {"<a href=\"#{url}\">", "</a>"}
+      end
+
+      defp get_styles_for_range(start, finish, inline_style_ranges) do
+        inline_style_ranges
+        |> Enum.filter(fn range -> is_in_range(range, start, finish) end)
+        |> Enum.map(fn range -> process_style(range["style"]) end)
+        |> Enum.join(" ")
+      end
+
+      defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map) do
+        entity_ranges
+        |> Enum.filter(fn range -> range["offset"] === start end)
+        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(0) end)
+      end
+
+      defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map) do
+        entity_ranges
+        |> Enum.filter(fn range -> range["offset"] + range["length"] === finish end)
+        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(1) end)
+        |> Enum.reverse()
+      end
+
+      defp is_in_range(range, start, finish) do
+        range_start = range["offset"]
+        range_finish = range["offset"] + range["length"]
+
+        start >= range_start && finish <= range_finish
+      end
+
+      @doc """
+      Takes multiple potentially overlapping ranges and breaks them into other mutually exclusive
+      ranges, so we can take each mini-range and add the specified, potentially multiple, styles
+      and entities to each mini-range
+
+      ## Examples
+          iex> ranges = [
+            %{"offset" => 0, "length" => 4, "style" => "ITALIC"},
+            %{"offset" => 4, "length" => 4, "style" => "BOLD"},
+            %{"offset" => 2, "length" => 3, "key" => 0}]
+          iex> consolidate_ranges(ranges)
+          [{0, 2}, {2, 4}, {4, 5}, {5, 8}]
+      """
+      defp consolidate_ranges(ranges) do
+        ranges
+        |> ranges_to_points()
+        |> points_to_ranges()
+      end
+
+      defp points_to_ranges(points) do
+        points
+        |> Enum.with_index
+        |> Enum.reduce([], fn {point, index}, acc ->
+          case Enum.at(points, index + 1) do
+            nil -> acc
+            next -> acc ++ [{point, next}]
+          end
+        end)
+      end
+
+      defp ranges_to_points(ranges) do
+        Enum.reduce(ranges, [], fn range, acc ->
+          acc ++ [range["offset"], range["offset"] + range["length"]]
+        end)
+        |> Enum.uniq
+        |> Enum.sort
+      end
+    end
   end
 end

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -1,0 +1,109 @@
+defmodule Draft.Ranges do
+  @moduledoc """
+  Provides functions for adding inline style ranges and entity ranges
+  """
+
+  def apply(text, inline_style_ranges, entity_ranges, entity_map) do
+    inline_style_ranges ++ entity_ranges
+    |> consolidate_ranges()
+    |> Enum.reduce(text, fn {start, finish}, acc ->
+      {style_opening_tag, style_closing_tag} =
+        case get_styles_for_range(start, finish, inline_style_ranges) do
+          "" -> {"", ""}
+          styles -> {"<span style=\"#{styles}\">", "</span>"}
+        end
+      entity_opening_tags = get_entity_opening_tags_for_start(start, entity_ranges, entity_map)
+      entity_closing_tags = get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map)
+      opening_tags = "#{entity_opening_tags}#{style_opening_tag}"
+      closing_tags = "#{style_closing_tag}#{entity_closing_tags}"
+
+      adjusted_start = start + String.length(acc) - String.length(text)
+      adjusted_finish = finish + String.length(acc) - String.length(text)
+
+      acc
+      |> String.split_at(adjusted_finish)
+      |> Tuple.to_list
+      |> Enum.join(closing_tags)
+      |> String.split_at(adjusted_start)
+      |> Tuple.to_list
+      |> Enum.join(opening_tags)
+    end)
+  end
+
+  defp process_style("BOLD") do
+    "font-weight: bold;"
+  end
+
+  defp process_style("ITALIC") do
+    "font-style: italic;"
+  end
+
+  defp process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}) do
+    {"<a href=\"#{url}\">", "</a>"}
+  end
+
+  defp get_styles_for_range(start, finish, inline_style_ranges) do
+    inline_style_ranges
+    |> Enum.filter(fn range -> is_in_range(range, start, finish) end)
+    |> Enum.map(fn range -> process_style(range["style"]) end)
+    |> Enum.join(" ")
+  end
+
+  defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map) do
+    entity_ranges
+    |> Enum.filter(fn range -> range["offset"] === start end)
+    |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(0) end)
+  end
+
+  defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map) do
+    entity_ranges
+    |> Enum.filter(fn range -> range["offset"] + range["length"] === finish end)
+    |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(1) end)
+    |> Enum.reverse()
+  end
+
+  defp is_in_range(range, start, finish) do
+    range_start = range["offset"]
+    range_finish = range["offset"] + range["length"]
+
+    start >= range_start && finish <= range_finish
+  end
+
+  @doc """
+  Takes multiple potentially overlapping ranges and breaks them into other mutually exclusive
+  ranges, so we can take each mini-range and add the specified, potentially multiple, styles
+  and entities to each mini-range
+
+  ## Examples
+      iex> ranges = [
+        %{"offset" => 0, "length" => 4, "style" => "ITALIC"},
+        %{"offset" => 4, "length" => 4, "style" => "BOLD"},
+        %{"offset" => 2, "length" => 3, "key" => 0}]
+      iex> consolidate_ranges(ranges)
+      [{0, 2}, {2, 4}, {4, 5}, {5, 8}]
+  """
+  defp consolidate_ranges(ranges) do
+    ranges
+    |> ranges_to_points()
+    |> points_to_ranges()
+  end
+
+  defp points_to_ranges(points) do
+    points
+    |> Enum.with_index
+    |> Enum.reduce([], fn {point, index}, acc ->
+      case Enum.at(points, index + 1) do
+        nil -> acc
+        next -> acc ++ [{point, next}]
+      end
+    end)
+  end
+
+  defp ranges_to_points(ranges) do
+    Enum.reduce(ranges, [], fn range, acc ->
+      acc ++ [range["offset"], range["offset"] + range["length"]]
+    end)
+    |> Enum.uniq
+    |> Enum.sort
+  end
+end

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -39,6 +39,10 @@ defmodule Draft.Ranges do
         "font-style: italic;"
       end
 
+      def process_style("UNDERLINE", _) do
+        "text-decoration: underline;"
+      end
+
       def process_entity(
             %{"type" => "LINK", "mutability" => "MUTABLE", "data" => %{"url" => url}},
             text,

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -54,13 +54,13 @@ defmodule Draft.Ranges do
       defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map, context) do
         entity_ranges
         |> Enum.filter(fn range -> range["offset"] === start end)
-        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity(context) |> elem(0) end)
+        |> Enum.map(fn range -> Map.get(entity_map, Integer.to_string(range["key"])) |> process_entity(context) |> elem(0) end)
       end
 
       defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map, context) do
         entity_ranges
         |> Enum.filter(fn range -> range["offset"] + range["length"] === finish end)
-        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity(context) |> elem(1) end)
+        |> Enum.map(fn range -> Map.get(entity_map, Integer.to_string(range["key"])) |> process_entity(context) |> elem(1) end)
         |> Enum.reverse()
       end
 

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -5,17 +5,17 @@ defmodule Draft.Ranges do
       Provides functions for adding inline style ranges and entity ranges
       """
 
-      def apply_ranges(text, inline_style_ranges, entity_ranges, entity_map) do
+      def apply_ranges(text, inline_style_ranges, entity_ranges, entity_map, context) do
         inline_style_ranges ++ entity_ranges
         |> consolidate_ranges()
         |> Enum.reduce(text, fn {start, finish}, acc ->
           {style_opening_tag, style_closing_tag} =
-            case get_styles_for_range(start, finish, inline_style_ranges) do
+            case get_styles_for_range(start, finish, inline_style_ranges, context) do
               "" -> {"", ""}
               styles -> {"<span style=\"#{styles}\">", "</span>"}
             end
-          entity_opening_tags = get_entity_opening_tags_for_start(start, entity_ranges, entity_map)
-          entity_closing_tags = get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map)
+          entity_opening_tags = get_entity_opening_tags_for_start(start, entity_ranges, entity_map, context)
+          entity_closing_tags = get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map, context)
           opening_tags = "#{entity_opening_tags}#{style_opening_tag}"
           closing_tags = "#{style_closing_tag}#{entity_closing_tags}"
 
@@ -32,35 +32,35 @@ defmodule Draft.Ranges do
         end)
       end
 
-      def process_style("BOLD") do
+      def process_style("BOLD", _) do
         "font-weight: bold;"
       end
 
-      def process_style("ITALIC") do
+      def process_style("ITALIC", _) do
         "font-style: italic;"
       end
 
-      def process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}) do
+      def process_entity(%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>url}}, _) do
         {"<a href=\"#{url}\">", "</a>"}
       end
 
-      defp get_styles_for_range(start, finish, inline_style_ranges) do
+      defp get_styles_for_range(start, finish, inline_style_ranges, context) do
         inline_style_ranges
         |> Enum.filter(fn range -> is_in_range(range, start, finish) end)
-        |> Enum.map(fn range -> process_style(range["style"]) end)
+        |> Enum.map(fn range -> process_style(range["style"], context) end)
         |> Enum.join(" ")
       end
 
-      defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map) do
+      defp get_entity_opening_tags_for_start(start, entity_ranges, entity_map, context) do
         entity_ranges
         |> Enum.filter(fn range -> range["offset"] === start end)
-        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(0) end)
+        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity(context) |> elem(0) end)
       end
 
-      defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map) do
+      defp get_entity_closing_tags_for_finish(finish, entity_ranges, entity_map, context) do
         entity_ranges
         |> Enum.filter(fn range -> range["offset"] + range["length"] === finish end)
-        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity() |> elem(1) end)
+        |> Enum.map(fn range -> Map.get(entity_map, range["key"]) |> process_entity(context) |> elem(1) end)
         |> Enum.reverse()
       end
 

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -20,7 +20,7 @@ defmodule Draft.Ranges do
                 |> Enum.map(fn style -> process_style(style, context) end)
                 |> Enum.join(" ")
 
-              "<span style=\"#{css}\">#{text}</span>"
+              "<span \n style=\"#{css}\">#{text}</span>"
 
             !is_nil(key) ->
               process_entity(entity_map |> Map.get(Integer.to_string(key)), text, context)

--- a/lib/draft/ranges.ex
+++ b/lib/draft/ranges.ex
@@ -20,7 +20,7 @@ defmodule Draft.Ranges do
                 |> Enum.map(fn style -> process_style(style, context) end)
                 |> Enum.join(" ")
 
-              "<span \n style=\"#{css}\">#{text}</span>"
+              "<span style=\"#{css}\">#{text}</span>"
 
             !is_nil(key) ->
               process_entity(entity_map |> Map.get(Integer.to_string(key)), text, context)

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -10,28 +10,40 @@ defmodule DraftTree do
   end
 
   defp insert_node(tree, range, text) do
-    first_included_child = Enum.find(tree.children, fn child ->
-      range["offset"] >= child.offset &&
-      (range["length"] + range["offset"]) <= (child.length + child.offset)
-    end)
+    first_included_child =
+      Enum.find(tree.children, fn child ->
+        range["offset"] >= child.offset &&
+          range["length"] + range["offset"] <= child.length + child.offset
+      end)
 
     case first_included_child do
       nil ->
-        Map.put(tree, :children, tree.children ++ [
-          %Node{
-            length: range["length"],
-            offset: range["offset"],
-            styles: range["styles"],
-            key: range["key"],
-            text: String.slice(text, range["offset"], range["length"])
-          }
-        ])
+        Map.put(
+          tree,
+          :children,
+          tree.children ++
+            [
+              %Node{
+                length: range["length"],
+                offset: range["offset"],
+                styles: range["styles"],
+                key: range["key"],
+                text: String.slice(text, range["offset"], range["length"])
+              }
+            ]
+        )
+
       child ->
         {all_but_last_item, _} = Enum.split(tree.children, length(tree.children) - 1)
 
-        Map.put(tree, :children, all_but_last_item ++ [
-          insert_node(child, range, text)
-        ])
+        Map.put(
+          tree,
+          :children,
+          all_but_last_item ++
+            [
+              insert_node(child, range, text)
+            ]
+        )
     end
   end
 
@@ -39,12 +51,24 @@ defmodule DraftTree do
     processor.(text, styles, key)
   end
 
-  def process_tree(%{children: children, key: key, styles: styles, offset: offset, length: length, text: text}, processor) do
+  def process_tree(
+        %{
+          children: children,
+          key: key,
+          styles: styles,
+          offset: offset,
+          length: length,
+          text: text
+        },
+        processor
+      ) do
     Enum.map(children, fn child -> {child, process_tree(child, processor)} end)
     |> Enum.reverse()
     |> Enum.reduce(text, fn {child, child_text}, acc ->
       {start, rest} = String.split_at(acc, child.offset - offset)
-      {_, finish} = String.split_at(rest, child.offset - offset + child.length - String.length(start))
+
+      {_, finish} =
+        String.split_at(rest, child.offset - offset + child.length - String.length(start))
 
       start <> child_text <> finish
     end)

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -1,0 +1,53 @@
+defmodule DraftTree do
+  defmodule Node do
+    defstruct offset: 0, length: 0, children: [], styles: [], key: nil, text: ""
+  end
+
+  def build_tree(ranges, text) do
+    root_node = %Node{text: text, length: String.length(text), styles: nil}
+
+    Enum.reduce(ranges, root_node, fn range, tree -> insert_node(tree, range, text) end)
+  end
+
+  defp insert_node(tree, range, text) do
+    first_included_child = Enum.find(tree.children, fn child ->
+      range["offset"] >= child.offset &&
+      (range["length"] + range["offset"]) <= (child.length + child.offset)
+    end)
+
+    case first_included_child do
+      nil ->
+        Map.put(tree, :children, tree.children ++ [
+          %Node{
+            length: range["length"],
+            offset: range["offset"],
+            styles: range["styles"],
+            key: range["key"],
+            text: String.slice(text, range["offset"], range["length"])
+          }
+        ])
+      child ->
+        {all_but_last_item, _} = Enum.split(tree.children, length(tree.children) - 1)
+
+        Map.put(tree, :children, all_but_last_item ++ [
+          insert_node(child, range, text)
+        ])
+    end
+  end
+
+  def process_tree(%{children: [], key: key, styles: styles, text: text}, processor) do
+    processor.(text, styles, key)
+  end
+
+  def process_tree(%{children: children, key: key, styles: styles, offset: offset, length: length, text: text}, processor) do
+    Enum.map(children, fn child -> {child, process_tree(child, processor)} end)
+    |> Enum.reverse()
+    |> Enum.reduce(text, fn {child, child_text}, acc ->
+      {start, rest} = String.split_at(acc, child.offset - offset)
+      {_, finish} = String.split_at(rest, child.offset - offset + child.length - String.length(start))
+
+      start <> child_text <> finish
+    end)
+    |> processor.(styles, key)
+  end
+end

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -57,7 +57,6 @@ defmodule DraftTree do
           key: key,
           styles: styles,
           offset: offset,
-          length: length,
           text: text
         },
         processor

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule Draft.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :draft,
-     version: "0.1.0",
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :draft,
+      version: "0.1.0",
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -29,8 +29,7 @@ defmodule Draft.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.3", only: [:dev, :test]},
-      {:ex_doc, "~> 0.14", only: :dev},
-      {:poison, "~> 2.0"}
+      {:ex_doc, "~> 0.14", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.5.2", "92e8c9f86e0ffbf9f688595e9f4e936bc96a52e5606d2c19713e9e4d191d5c74", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+}

--- a/test/custom_entity_test.exs
+++ b/test/custom_entity_test.exs
@@ -3,31 +3,42 @@ defmodule CustomEntityTest do
   use Draft
 
   def process_entity(
-    %{"type"=>"PERSONALIZATION",
-      "mutability"=>"IMMUTABLE",
-      "data"=>%{"value"=>value}}, _text, [contact: contact]) do
+        %{
+          "type" => "PERSONALIZATION",
+          "mutability" => "IMMUTABLE",
+          "data" => %{"value" => value}
+        },
+        _text,
+        contact: contact
+      ) do
     contact |> Map.get(value)
   end
 
   test "nests entities that potentially replace content inside styles" do
     input = %{
-      "blocks" => [%{
-        "key" => "ck6bi",
-        "data" => %{},
-        "text" => "#CONTACT.NAME_FULL",
-        "type" => "unstyled",
-        "depth" => 0,
-        "entityRanges" => [%{
-          "key" => 0,
-          "length" => 18,
-          "offset" => 0
-        }],
-        "inlineStyleRanges" => [%{
-          "style" => "BOLD",
-          "length" => 18,
-          "offset" => 0
-        }]
-      }],
+      "blocks" => [
+        %{
+          "key" => "ck6bi",
+          "data" => %{},
+          "text" => "#CONTACT.NAME_FULL",
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [
+            %{
+              "key" => 0,
+              "length" => 18,
+              "offset" => 0
+            }
+          ],
+          "inlineStyleRanges" => [
+            %{
+              "style" => "BOLD",
+              "length" => 18,
+              "offset" => 0
+            }
+          ]
+        }
+      ],
       "entityMap" => %{
         "0" => %{
           "data" => %{
@@ -40,31 +51,33 @@ defmodule CustomEntityTest do
     }
 
     assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
-      "<p><span style=\"font-weight: bold;\">Frodo</span></p>"
+             "<p><span style=\"font-weight: bold;\">Frodo</span></p>"
   end
 
   test "ranges adjacent to entities that potentially replace content" do
     input = %{
-      "blocks" => [%{
-        "key" => "ck6bi",
-        "data" => %{},
-        "text" => "It's going great #CONTACT.NAME_FULL. Right?",
-        "type" => "unstyled",
-        "depth" => 0,
-        "entityRanges" => [%{
-          "key" => 0,
-          "length" => 5,
-          "offset" => 5
-        }, %{
-          "key" => 1,
-          "length" => 18,
-          "offset" => 17
-        }],
-        "inlineStyleRanges" => [
-          %{"style" => "BOLD",
-            "length" => 5,
-            "offset" => 37}]
-      }],
+      "blocks" => [
+        %{
+          "key" => "ck6bi",
+          "data" => %{},
+          "text" => "It's going great #CONTACT.NAME_FULL. Right?",
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [
+            %{
+              "key" => 0,
+              "length" => 5,
+              "offset" => 5
+            },
+            %{
+              "key" => 1,
+              "length" => 18,
+              "offset" => 17
+            }
+          ],
+          "inlineStyleRanges" => [%{"style" => "BOLD", "length" => 5, "offset" => 37}]
+        }
+      ],
       "entityMap" => %{
         "0" => %{
           "data" => %{
@@ -84,36 +97,44 @@ defmodule CustomEntityTest do
     }
 
     assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
-      "<p>It's <a href=\"http://google.com\">going</a> great Frodo. <span style=\"font-weight: bold;\">Right</span>?</p>"
+             "<p>It's <a href=\"http://google.com\">going</a> great Frodo. <span style=\"font-weight: bold;\">Right</span>?</p>"
   end
 
   test "a random complex combination" do
     input = %{
-      "blocks" => [%{
-        "key" => "ck6bi",
-        "data" => %{},
-        "text" => "It's going great #CONTACT.NAME_FULL. Right?",
-        "type" => "unstyled",
-        "depth" => 0,
-        "entityRanges" => [%{
-          "key" => 0,
-          "length" => 38,
-          "offset" => 5
-        }, %{
-          "key" => 1,
-          "length" => 18,
-          "offset" => 17
-        }],
-        "inlineStyleRanges" => [%{
-          "style" => "BOLD",
-          "length" => 1,
-          "offset" => 0
-        }, %{
-          "style" => "BOLD",
-          "length" => 26,
-          "offset" => 11
-        }]
-      }],
+      "blocks" => [
+        %{
+          "key" => "ck6bi",
+          "data" => %{},
+          "text" => "It's going great #CONTACT.NAME_FULL. Right?",
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [
+            %{
+              "key" => 0,
+              "length" => 38,
+              "offset" => 5
+            },
+            %{
+              "key" => 1,
+              "length" => 18,
+              "offset" => 17
+            }
+          ],
+          "inlineStyleRanges" => [
+            %{
+              "style" => "BOLD",
+              "length" => 1,
+              "offset" => 0
+            },
+            %{
+              "style" => "BOLD",
+              "length" => 26,
+              "offset" => 11
+            }
+          ]
+        }
+      ],
       "entityMap" => %{
         "0" => %{
           "data" => %{
@@ -133,6 +154,6 @@ defmodule CustomEntityTest do
     }
 
     assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
-      "<p><span style=\"font-weight: bold;\">I</span>t's <a href=\"http://google.com\">going <span style=\"font-weight: bold;\">great </span><span style=\"font-weight: bold;\">Frodo</span><span style=\"font-weight: bold;\">. </span>Right?</a></p>"
+             "<p><span style=\"font-weight: bold;\">I</span>t's <a href=\"http://google.com\">going <span style=\"font-weight: bold;\">great </span><span style=\"font-weight: bold;\">Frodo</span><span style=\"font-weight: bold;\">. </span>Right?</a></p>"
   end
 end

--- a/test/custom_entity_test.exs
+++ b/test/custom_entity_test.exs
@@ -1,0 +1,138 @@
+defmodule CustomEntityTest do
+  use ExUnit.Case
+  use Draft
+
+  def process_entity(
+    %{"type"=>"PERSONALIZATION",
+      "mutability"=>"IMMUTABLE",
+      "data"=>%{"value"=>value}}, _text, [contact: contact]) do
+    contact |> Map.get(value)
+  end
+
+  test "nests entities that potentially replace content inside styles" do
+    input = %{
+      "blocks" => [%{
+        "key" => "ck6bi",
+        "data" => %{},
+        "text" => "#CONTACT.NAME_FULL",
+        "type" => "unstyled",
+        "depth" => 0,
+        "entityRanges" => [%{
+          "key" => 0,
+          "length" => 18,
+          "offset" => 0
+        }],
+        "inlineStyleRanges" => [%{
+          "style" => "BOLD",
+          "length" => 18,
+          "offset" => 0
+        }]
+      }],
+      "entityMap" => %{
+        "0" => %{
+          "data" => %{
+            "value" => "name"
+          },
+          "type" => "PERSONALIZATION",
+          "mutability" => "IMMUTABLE"
+        }
+      }
+    }
+
+    assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
+      "<p><span style=\"font-weight: bold;\">Frodo</span></p>"
+  end
+
+  test "ranges adjacent to entities that potentially replace content" do
+    input = %{
+      "blocks" => [%{
+        "key" => "ck6bi",
+        "data" => %{},
+        "text" => "It's going great #CONTACT.NAME_FULL. Right?",
+        "type" => "unstyled",
+        "depth" => 0,
+        "entityRanges" => [%{
+          "key" => 0,
+          "length" => 5,
+          "offset" => 5
+        }, %{
+          "key" => 1,
+          "length" => 18,
+          "offset" => 17
+        }],
+        "inlineStyleRanges" => [
+          %{"style" => "BOLD",
+            "length" => 5,
+            "offset" => 37}]
+      }],
+      "entityMap" => %{
+        "0" => %{
+          "data" => %{
+            "url" => "http://google.com"
+          },
+          "type" => "LINK",
+          "mutability" => "MUTABLE"
+        },
+        "1" => %{
+          "data" => %{
+            "value" => "name"
+          },
+          "type" => "PERSONALIZATION",
+          "mutability" => "IMMUTABLE"
+        }
+      }
+    }
+
+    assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
+      "<p>It's <a href=\"http://google.com\">going</a> great Frodo. <span style=\"font-weight: bold;\">Right</span>?</p>"
+  end
+
+  test "a random complex combination" do
+    input = %{
+      "blocks" => [%{
+        "key" => "ck6bi",
+        "data" => %{},
+        "text" => "It's going great #CONTACT.NAME_FULL. Right?",
+        "type" => "unstyled",
+        "depth" => 0,
+        "entityRanges" => [%{
+          "key" => 0,
+          "length" => 38,
+          "offset" => 5
+        }, %{
+          "key" => 1,
+          "length" => 18,
+          "offset" => 17
+        }],
+        "inlineStyleRanges" => [%{
+          "style" => "BOLD",
+          "length" => 1,
+          "offset" => 0
+        }, %{
+          "style" => "BOLD",
+          "length" => 26,
+          "offset" => 11
+        }]
+      }],
+      "entityMap" => %{
+        "0" => %{
+          "data" => %{
+            "url" => "http://google.com"
+          },
+          "type" => "LINK",
+          "mutability" => "MUTABLE"
+        },
+        "1" => %{
+          "data" => %{
+            "value" => "name"
+          },
+          "type" => "PERSONALIZATION",
+          "mutability" => "IMMUTABLE"
+        }
+      }
+    }
+
+    assert to_html(input, contact: %{"name" => "Frodo", "email" => "frodo@middleearth.com"}) ==
+      "<p><span style=\"font-weight: bold;\">I</span>t's <a href=\"http://google.com\">going <span style=\"font-weight: bold;\">great </span><span style=\"font-weight: bold;\">Frodo</span><span style=\"font-weight: bold;\">. </span>Right?</a></p>"
+  end
+end

--- a/test/draft/tree_test.exs
+++ b/test/draft/tree_test.exs
@@ -2,62 +2,75 @@ defmodule TreeTest do
   use ExUnit.Case
 
   test "builds a tree" do
-    assert DraftTree.build_tree([
-      %{"length" => 1, "offset" => 0, "styles" => ["BOLD"]},
-      %{"key" => 0, "length" => 38, "offset" => 5},
-      %{"length" => 6, "offset" => 11, "styles" => ["BOLD"]},
-      %{"length" => 18, "offset" => 17, "styles" => ["BOLD"]},
-      %{"key" => 1, "length" => 18, "offset" => 17},
-      %{"length" => 2, "offset" => 35, "styles" => ["BOLD"]}
-    ], "It's going great #CONTACT.NAME_FULL. Right?") ==
-      %DraftTree.Node{
-        key: nil,
-        length: 43,
-        offset: 0,
-        styles: nil,
-        text: "It's going great #CONTACT.NAME_FULL. Right?",
-        children: [
-          %DraftTree.Node{
-            key: nil,
-            length: 1,
-            offset: 0,
-            styles: ["BOLD"],
-            text: "I",
-            children: []},
-          %DraftTree.Node{
-            key: 0,
-            length: 38,
-            offset: 5,
-            styles: nil,
-            text: "going great #CONTACT.NAME_FULL. Right?",
-            children: [
-              %DraftTree.Node{
-                key: nil,
-                length: 6,
-                offset: 11,
-                styles: ["BOLD"],
-                text: "great ",
-                children: []},
-              %DraftTree.Node{
-                key: nil,
-                length: 18,
-                offset: 17,
-                styles: ["BOLD"],
-                text: "#CONTACT.NAME_FULL",
-                children: [
-                  %DraftTree.Node{
-                    key: 1,
-                    length: 18,
-                    offset: 17,
-                    styles: nil,
-                    text: "#CONTACT.NAME_FULL",
-                    children: []}]},
-              %DraftTree.Node{
-                key: nil,
-                length: 2,
-                offset: 35,
-                styles: ["BOLD"],
-                text: ". ",
-                children: []}]}]}
+    assert DraftTree.build_tree(
+             [
+               %{"length" => 1, "offset" => 0, "styles" => ["BOLD"]},
+               %{"key" => 0, "length" => 38, "offset" => 5},
+               %{"length" => 6, "offset" => 11, "styles" => ["BOLD"]},
+               %{"length" => 18, "offset" => 17, "styles" => ["BOLD"]},
+               %{"key" => 1, "length" => 18, "offset" => 17},
+               %{"length" => 2, "offset" => 35, "styles" => ["BOLD"]}
+             ],
+             "It's going great #CONTACT.NAME_FULL. Right?"
+           ) ==
+             %DraftTree.Node{
+               key: nil,
+               length: 43,
+               offset: 0,
+               styles: nil,
+               text: "It's going great #CONTACT.NAME_FULL. Right?",
+               children: [
+                 %DraftTree.Node{
+                   key: nil,
+                   length: 1,
+                   offset: 0,
+                   styles: ["BOLD"],
+                   text: "I",
+                   children: []
+                 },
+                 %DraftTree.Node{
+                   key: 0,
+                   length: 38,
+                   offset: 5,
+                   styles: nil,
+                   text: "going great #CONTACT.NAME_FULL. Right?",
+                   children: [
+                     %DraftTree.Node{
+                       key: nil,
+                       length: 6,
+                       offset: 11,
+                       styles: ["BOLD"],
+                       text: "great ",
+                       children: []
+                     },
+                     %DraftTree.Node{
+                       key: nil,
+                       length: 18,
+                       offset: 17,
+                       styles: ["BOLD"],
+                       text: "#CONTACT.NAME_FULL",
+                       children: [
+                         %DraftTree.Node{
+                           key: 1,
+                           length: 18,
+                           offset: 17,
+                           styles: nil,
+                           text: "#CONTACT.NAME_FULL",
+                           children: []
+                         }
+                       ]
+                     },
+                     %DraftTree.Node{
+                       key: nil,
+                       length: 2,
+                       offset: 35,
+                       styles: ["BOLD"],
+                       text: ". ",
+                       children: []
+                     }
+                   ]
+                 }
+               ]
+             }
   end
 end

--- a/test/draft/tree_test.exs
+++ b/test/draft/tree_test.exs
@@ -1,0 +1,63 @@
+defmodule TreeTest do
+  use ExUnit.Case
+
+  test "builds a tree" do
+    assert DraftTree.build_tree([
+      %{"length" => 1, "offset" => 0, "styles" => ["BOLD"]},
+      %{"key" => 0, "length" => 38, "offset" => 5},
+      %{"length" => 6, "offset" => 11, "styles" => ["BOLD"]},
+      %{"length" => 18, "offset" => 17, "styles" => ["BOLD"]},
+      %{"key" => 1, "length" => 18, "offset" => 17},
+      %{"length" => 2, "offset" => 35, "styles" => ["BOLD"]}
+    ], "It's going great #CONTACT.NAME_FULL. Right?") ==
+      %DraftTree.Node{
+        key: nil,
+        length: 43,
+        offset: 0,
+        styles: nil,
+        text: "It's going great #CONTACT.NAME_FULL. Right?",
+        children: [
+          %DraftTree.Node{
+            key: nil,
+            length: 1,
+            offset: 0,
+            styles: ["BOLD"],
+            text: "I",
+            children: []},
+          %DraftTree.Node{
+            key: 0,
+            length: 38,
+            offset: 5,
+            styles: nil,
+            text: "going great #CONTACT.NAME_FULL. Right?",
+            children: [
+              %DraftTree.Node{
+                key: nil,
+                length: 6,
+                offset: 11,
+                styles: ["BOLD"],
+                text: "great ",
+                children: []},
+              %DraftTree.Node{
+                key: nil,
+                length: 18,
+                offset: 17,
+                styles: ["BOLD"],
+                text: "#CONTACT.NAME_FULL",
+                children: [
+                  %DraftTree.Node{
+                    key: 1,
+                    length: 18,
+                    offset: 17,
+                    styles: nil,
+                    text: "#CONTACT.NAME_FULL",
+                    children: []}]},
+              %DraftTree.Node{
+                key: nil,
+                length: 2,
+                offset: 35,
+                styles: ["BOLD"],
+                text: ". ",
+                children: []}]}]}
+  end
+end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -1,65 +1,65 @@
 defmodule DraftTest do
   use ExUnit.Case
-  doctest Draft
+  use Draft
 
   test "generate a <p>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<p>Hello</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "generate a <h1>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-one","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h1>Hello</h1>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "generate a <h2>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-two","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h2>Hello</h2>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "generate a <h3>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-three","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h3>Hello</h3>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "generate a <blockquote>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"blockquote","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<blockquote>Hello</blockquote>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "generate a <br>" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<br>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps single inline style" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello","inlineStyleRanges"=>[%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
     output = "<p>He<span style=\"font-weight: bold;\">ll</span>o</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps multiple inline styles" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>8,"length"=>3},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
     output = "<p>He<span style=\"font-weight: bold;\">ll</span>o Wo<span style=\"font-style: italic;\">rld</span>!</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps nested inline styles" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
     output = "<p>He<span style=\"font-style: italic; font-weight: bold;\">ll</span><span style=\"font-style: italic;\">o W</span>orld!</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps overlapping inline styles" do
     input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5}, %{"style"=>"BOLD","offset"=>4,"length"=>5}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
     output = "<p>He<span style=\"font-style: italic;\">ll</span><span style=\"font-style: italic; font-weight: bold;\">o W</span><span style=\"font-weight: bold;\">or</span>ld!</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps anchor entities" do
@@ -68,7 +68,7 @@ defmodule DraftTest do
                             %{"offset"=>2,"length"=>3,"key"=>0}
                           ],"data"=>%{},"key"=>"9d21d"}]}
     output = "<p>He<a href=\"http://google.com\">llo</a> World!</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 
   test "wraps overlapping entities and inline styles" do
@@ -85,6 +85,6 @@ defmodule DraftTest do
                            "depth"=>0,
                            "data"=>%{},"key"=>"9d21d"}]}
     output = "<p><span style=\"font-style: italic;\">He</span><a href=\"http://google.com\"><span style=\"font-style: italic;\">ll</span><span style=\"font-weight: bold;\">o</span></a><span style=\"font-weight: bold;\"> Wo</span>rld!</p>"
-    assert Draft.to_html(input) == output
+    assert to_html(input) == output
   end
 end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -82,6 +82,66 @@ defmodule DraftTest do
     assert to_html(input) == output
   end
 
+  test "generate a <h4>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-four",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h4>Hello</h4>"
+    assert to_html(input) == output
+  end
+
+  test "generate a <h5>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-five",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h5>Hello</h5>"
+    assert to_html(input) == output
+  end
+
+  test "generate a <h6>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-six",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h6>Hello</h6>"
+    assert to_html(input) == output
+  end
+
   test "generate a <blockquote>" do
     input = %{
       "entityMap" => %{},

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -339,6 +339,49 @@ defmodule DraftTest do
     assert to_html(input) == output
   end
 
+  test "anchor entities text is wrapped by an inline style span tag" do
+    input = %{
+      "blocks" => [
+        %{
+          "depth" => 0,
+          "entityRanges" => [
+            %{
+              "key" => 0,
+              "offset" => 0,
+              "length" => 6
+            }
+          ],
+          "inlineStyleRanges" => [
+            %{
+              "style" => "BOLD",
+              "offset" => 0,
+              "length" => 6
+            }
+          ],
+          "data" => %{},
+          "text" => "Google",
+          "key" => "c2jk5",
+          "type" => "unstyled"
+        }
+      ],
+      "entityMap" => %{
+        "0" => %{
+          "type" => "LINK",
+          "data" => %{
+            "url" => "https=>\/\/www.google.com",
+            "target" => "_blank"
+          },
+          "mutability" => "MUTABLE"
+        }
+      }
+    }
+
+    output =
+      "<p><a href=\"https=>//www.google.com\"><span style=\"font-weight: bold;\">Google</span></a></p>"
+
+    assert to_html(input) == output
+  end
+
   test "wraps ordered lists in <ol>" do
     input = %{
       "entityMap" => %{},

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -3,121 +3,405 @@ defmodule DraftTest do
   use Draft
 
   test "generate a <p>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "unstyled",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<p>Hello</p>"
     assert to_html(input) == output
   end
 
   test "generate a <h1>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-one","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-one",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<h1>Hello</h1>"
     assert to_html(input) == output
   end
 
   test "generate a <h2>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-two","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-two",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<h2>Hello</h2>"
     assert to_html(input) == output
   end
 
   test "generate a <h3>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-three","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-three",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<h3>Hello</h3>"
     assert to_html(input) == output
   end
 
   test "generate a <blockquote>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"blockquote","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "blockquote",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<blockquote>Hello</blockquote>"
     assert to_html(input) == output
   end
 
   test "generate a <br>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "",
+          "type" => "unstyled",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<br>"
     assert to_html(input) == output
   end
 
   test "wraps single inline style" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello","inlineStyleRanges"=>[%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "text" => "Hello",
+          "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 2, "length" => 2}],
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [],
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
     output = "<p>He<span style=\"font-weight: bold;\">ll</span>o</p>"
     assert to_html(input) == output
   end
 
   test "wraps multiple inline styles" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>8,"length"=>3},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
-    output = "<p>He<span style=\"font-weight: bold;\">ll</span>o Wo<span style=\"font-style: italic;\">rld</span>!</p>"
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "text" => "Hello World!",
+          "inlineStyleRanges" => [
+            %{"style" => "ITALIC", "offset" => 8, "length" => 3},
+            %{"style" => "BOLD", "offset" => 2, "length" => 2}
+          ],
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [],
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
+    output =
+      "<p>He<span style=\"font-weight: bold;\">ll</span>o Wo<span style=\"font-style: italic;\">rld</span>!</p>"
+
     assert to_html(input) == output
   end
 
   test "wraps nested inline styles" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
-    output = "<p>He<span style=\"font-style: italic; font-weight: bold;\">ll</span><span style=\"font-style: italic;\">o W</span>orld!</p>"
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "text" => "Hello World!",
+          "inlineStyleRanges" => [
+            %{"style" => "ITALIC", "offset" => 2, "length" => 5},
+            %{"style" => "BOLD", "offset" => 2, "length" => 2}
+          ],
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [],
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
+    output =
+      "<p>He<span style=\"font-style: italic; font-weight: bold;\">ll</span><span style=\"font-style: italic;\">o W</span>orld!</p>"
+
     assert to_html(input) == output
   end
 
   test "wraps overlapping inline styles" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5}, %{"style"=>"BOLD","offset"=>4,"length"=>5}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
-    output = "<p>He<span style=\"font-style: italic;\">ll</span><span style=\"font-style: italic; font-weight: bold;\">o W</span><span style=\"font-weight: bold;\">or</span>ld!</p>"
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "text" => "Hello World!",
+          "inlineStyleRanges" => [
+            %{"style" => "ITALIC", "offset" => 2, "length" => 5},
+            %{"style" => "BOLD", "offset" => 4, "length" => 5}
+          ],
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [],
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
+    output =
+      "<p>He<span style=\"font-style: italic;\">ll</span><span style=\"font-style: italic; font-weight: bold;\">o W</span><span style=\"font-weight: bold;\">or</span>ld!</p>"
+
     assert to_html(input) == output
   end
 
   test "wraps anchor entities" do
-    input = %{"entityMap"=>%{"0"=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
-              "blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[],"type"=>"unstyled","depth"=>0,"entityRanges"=>[
-                            %{"offset"=>2,"length"=>3,"key"=>0}
-                          ],"data"=>%{},"key"=>"9d21d"}]}
+    input = %{
+      "entityMap" => %{
+        "0" => %{
+          "type" => "LINK",
+          "mutability" => "MUTABLE",
+          "data" => %{"url" => "http://google.com"}
+        }
+      },
+      "blocks" => [
+        %{
+          "text" => "Hello World!",
+          "inlineStyleRanges" => [],
+          "type" => "unstyled",
+          "depth" => 0,
+          "entityRanges" => [
+            %{"offset" => 2, "length" => 3, "key" => 0}
+          ],
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
     output = "<p>He<a href=\"http://google.com\">llo</a> World!</p>"
     assert to_html(input) == output
   end
 
   test "wraps overlapping entities and inline styles" do
-    input = %{"entityMap"=>%{"0"=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
-              "blocks"=>[%{"text"=>"Hello World!",
-                           "inlineStyleRanges"=>[
-                             %{"style"=>"ITALIC","offset"=>0,"length"=>4},
-                             %{"style"=>"BOLD","offset"=>4,"length"=>4},
-                           ],
-                           "entityRanges"=>[
-                             %{"offset"=>2,"length"=>3,"key"=>0}
-                           ],
-                           "type"=>"unstyled",
-                           "depth"=>0,
-                           "data"=>%{},"key"=>"9d21d"}]}
-    output = "<p><span style=\"font-style: italic;\">He</span><a href=\"http://google.com\"><span style=\"font-style: italic;\">ll</span><span style=\"font-weight: bold;\">o</span></a><span style=\"font-weight: bold;\"> Wo</span>rld!</p>"
+    input = %{
+      "entityMap" => %{
+        "0" => %{
+          "type" => "LINK",
+          "mutability" => "MUTABLE",
+          "data" => %{"url" => "http://google.com"}
+        }
+      },
+      "blocks" => [
+        %{
+          "text" => "Hello World!",
+          "inlineStyleRanges" => [
+            %{"style" => "ITALIC", "offset" => 0, "length" => 4},
+            %{"style" => "BOLD", "offset" => 4, "length" => 4}
+          ],
+          "entityRanges" => [
+            %{"offset" => 2, "length" => 3, "key" => 0}
+          ],
+          "type" => "unstyled",
+          "depth" => 0,
+          "data" => %{},
+          "key" => "9d21d"
+        }
+      ]
+    }
+
+    output =
+      "<p><span style=\"font-style: italic;\">He</span><a href=\"http://google.com\"><span style=\"font-style: italic;\">ll</span><span style=\"font-weight: bold;\">o</span></a><span style=\"font-weight: bold;\"> Wo</span>rld!</p>"
+
     assert to_html(input) == output
   end
 
   test "wraps ordered lists in <ol>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"one","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "one",
+          "type" => "ordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<ol><li>one</li></ol>"
     assert to_html(input) == output
   end
 
   test "wraps unordered lists in <ul>" do
-    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "one",
+          "type" => "unordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<ul><li>one</li></ul>"
     assert to_html(input) == output
   end
 
   test "wraps multiple unordered list items in the same <ul>" do
-    input = %{"entityMap"=>%{},"blocks"=>[
-               %{"key"=>"9d21d","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
-               %{"key"=>"9d21e","text"=>"two","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}
-             ]}
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "one",
+          "type" => "unordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        },
+        %{
+          "key" => "9d21e",
+          "text" => "two",
+          "type" => "unordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
     output = "<ul><li>one</li><li>two</li></ul>"
     assert to_html(input) == output
   end
 
   test "wraps multiple complex lists" do
-    input = %{"entityMap"=>%{},"blocks"=>[
-               %{"key"=>"9d21c","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
-               %{"key"=>"9d21e","text"=>"whoops","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
-               %{"key"=>"9d21d","text"=>"two","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
-               %{"key"=>"9d21f","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
-               %{"key"=>"9d21g","text"=>"and another","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}
-             ]}
-    output = "<ul><li>one</li></ul><ol><li>whoops</li></ol><ul><li>two</li></ul><p>Hello</p><ol><li>and another</li></ol>"
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21c",
+          "text" => "one",
+          "type" => "unordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        },
+        %{
+          "key" => "9d21e",
+          "text" => "whoops",
+          "type" => "ordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        },
+        %{
+          "key" => "9d21d",
+          "text" => "two",
+          "type" => "unordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        },
+        %{
+          "key" => "9d21f",
+          "text" => "Hello",
+          "type" => "unstyled",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        },
+        %{
+          "key" => "9d21g",
+          "text" => "and another",
+          "type" => "ordered-list-item",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output =
+      "<ul><li>one</li></ul><ol><li>whoops</li></ol><ul><li>two</li></ul><p>Hello</p><ol><li>and another</li></ol>"
+
     assert to_html(input) == output
   end
 end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -3,37 +3,37 @@ defmodule DraftTest do
   doctest Draft
 
   test "generate a <p>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"Hello","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<p>Hello</p>"
     assert Draft.to_html(input) == output
   end
 
   test "generate a <h1>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"Hello","type":"header-one","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-one","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h1>Hello</h1>"
     assert Draft.to_html(input) == output
   end
 
   test "generate a <h2>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"Hello","type":"header-two","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-two","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h2>Hello</h2>"
     assert Draft.to_html(input) == output
   end
 
   test "generate a <h3>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"Hello","type":"header-three","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"header-three","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<h3>Hello</h3>"
     assert Draft.to_html(input) == output
   end
 
   test "generate a <blockquote>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"Hello","type":"blockquote","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"Hello","type"=>"blockquote","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<blockquote>Hello</blockquote>"
     assert Draft.to_html(input) == output
   end
 
   test "generate a <br>" do
-    input = ~s({"entityMap":{},"blocks":[{"key":"9d21d","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]})
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
     output = "<br>"
     assert Draft.to_html(input) == output
   end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -354,7 +354,7 @@ defmodule DraftTest do
       ]
     }
 
-    output = "<ol><li>one</li></ol>"
+    output = "<ol><li style=\"mso-special-format:numbullet;\">one</li></ol>"
     assert to_html(input) == output
   end
 
@@ -374,7 +374,7 @@ defmodule DraftTest do
       ]
     }
 
-    output = "<ul><li>one</li></ul>"
+    output = "<ul><li style=\"mso-special-format:bullet;\">one</li></ul>"
     assert to_html(input) == output
   end
 
@@ -403,7 +403,9 @@ defmodule DraftTest do
       ]
     }
 
-    output = "<ul><li>one</li><li>two</li></ul>"
+    output =
+      "<ul><li style=\"mso-special-format:bullet;\">one</li><li style=\"mso-special-format:bullet;\">two</li></ul>"
+
     assert to_html(input) == output
   end
 
@@ -460,7 +462,7 @@ defmodule DraftTest do
     }
 
     output =
-      "<ul><li>one</li></ul><ol><li>whoops</li></ol><ul><li>two</li></ul><p>Hello</p><ol><li>and another</li></ol>"
+      "<ul><li style=\"mso-special-format:bullet;\">one</li></ul><ol><li style=\"mso-special-format:numbullet;\">whoops</li></ol><ul><li style=\"mso-special-format:bullet;\">two</li></ul><p>Hello</p><ol><li style=\"mso-special-format:numbullet;\">and another</li></ol>"
 
     assert to_html(input) == output
   end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -87,4 +87,37 @@ defmodule DraftTest do
     output = "<p><span style=\"font-style: italic;\">He</span><a href=\"http://google.com\"><span style=\"font-style: italic;\">ll</span><span style=\"font-weight: bold;\">o</span></a><span style=\"font-weight: bold;\"> Wo</span>rld!</p>"
     assert to_html(input) == output
   end
+
+  test "wraps ordered lists in <ol>" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"one","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    output = "<ol><li>one</li></ol>"
+    assert to_html(input) == output
+  end
+
+  test "wraps unordered lists in <ul>" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"key"=>"9d21d","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}]}
+    output = "<ul><li>one</li></ul>"
+    assert to_html(input) == output
+  end
+
+  test "wraps multiple unordered list items in the same <ul>" do
+    input = %{"entityMap"=>%{},"blocks"=>[
+               %{"key"=>"9d21d","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
+               %{"key"=>"9d21e","text"=>"two","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}
+             ]}
+    output = "<ul><li>one</li><li>two</li></ul>"
+    assert to_html(input) == output
+  end
+
+  test "wraps multiple complex lists" do
+    input = %{"entityMap"=>%{},"blocks"=>[
+               %{"key"=>"9d21c","text"=>"one","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
+               %{"key"=>"9d21e","text"=>"whoops","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
+               %{"key"=>"9d21d","text"=>"two","type"=>"unordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
+               %{"key"=>"9d21f","text"=>"Hello","type"=>"unstyled","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}},
+               %{"key"=>"9d21g","text"=>"and another","type"=>"ordered-list-item","depth"=>0,"inlineStyleRanges"=>[],"entityRanges"=>[],"data"=>%{}}
+             ]}
+    output = "<ul><li>one</li></ul><ol><li>whoops</li></ol><ul><li>two</li></ul><p>Hello</p><ol><li>and another</li></ol>"
+    assert to_html(input) == output
+  end
 end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -37,4 +37,54 @@ defmodule DraftTest do
     output = "<br>"
     assert Draft.to_html(input) == output
   end
+
+  test "wraps single inline style" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello","inlineStyleRanges"=>[%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
+    output = "<p>He<span style=\"font-weight: bold;\">ll</span>o</p>"
+    assert Draft.to_html(input) == output
+  end
+
+  test "wraps multiple inline styles" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>8,"length"=>3},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
+    output = "<p>He<span style=\"font-weight: bold;\">ll</span>o Wo<span style=\"font-style: italic;\">rld</span>!</p>"
+    assert Draft.to_html(input) == output
+  end
+
+  test "wraps nested inline styles" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5},%{"style"=>"BOLD","offset"=>2,"length"=>2}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
+    output = "<p>He<span style=\"font-style: italic; font-weight: bold;\">ll</span><span style=\"font-style: italic;\">o W</span>orld!</p>"
+    assert Draft.to_html(input) == output
+  end
+
+  test "wraps overlapping inline styles" do
+    input = %{"entityMap"=>%{},"blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[%{"style"=>"ITALIC","offset"=>2,"length"=>5}, %{"style"=>"BOLD","offset"=>4,"length"=>5}],"type"=>"unstyled","depth"=>0,"entityRanges"=>[],"data"=>%{},"key"=>"9d21d"}]}
+    output = "<p>He<span style=\"font-style: italic;\">ll</span><span style=\"font-style: italic; font-weight: bold;\">o W</span><span style=\"font-weight: bold;\">or</span>ld!</p>"
+    assert Draft.to_html(input) == output
+  end
+
+  test "wraps anchor entities" do
+    input = %{"entityMap"=>%{0=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
+              "blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[],"type"=>"unstyled","depth"=>0,"entityRanges"=>[
+                            %{"offset"=>2,"length"=>3,"key"=>0}
+                          ],"data"=>%{},"key"=>"9d21d"}]}
+    output = "<p>He<a href=\"http://google.com\">llo</a> World!</p>"
+    assert Draft.to_html(input) == output
+  end
+
+  test "wraps overlapping entities and inline styles" do
+    input = %{"entityMap"=>%{0=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
+              "blocks"=>[%{"text"=>"Hello World!",
+                           "inlineStyleRanges"=>[
+                             %{"style"=>"ITALIC","offset"=>0,"length"=>4},
+                             %{"style"=>"BOLD","offset"=>4,"length"=>4},
+                           ],
+                           "entityRanges"=>[
+                             %{"offset"=>2,"length"=>3,"key"=>0}
+                           ],
+                           "type"=>"unstyled",
+                           "depth"=>0,
+                           "data"=>%{},"key"=>"9d21d"}]}
+    output = "<p><span style=\"font-style: italic;\">He</span><a href=\"http://google.com\"><span style=\"font-style: italic;\">ll</span><span style=\"font-weight: bold;\">o</span></a><span style=\"font-weight: bold;\"> Wo</span>rld!</p>"
+    assert Draft.to_html(input) == output
+  end
 end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -210,7 +210,8 @@ defmodule DraftTest do
           "text" => "Hello World!",
           "inlineStyleRanges" => [
             %{"style" => "ITALIC", "offset" => 8, "length" => 3},
-            %{"style" => "BOLD", "offset" => 2, "length" => 2}
+            %{"style" => "BOLD", "offset" => 2, "length" => 2},
+            %{"style" => "UNDERLINE", "offset" => 4, "length" => 4}
           ],
           "type" => "unstyled",
           "depth" => 0,
@@ -222,7 +223,7 @@ defmodule DraftTest do
     }
 
     output =
-      "<p>He<span style=\"font-weight: bold;\">ll</span>o Wo<span style=\"font-style: italic;\">rld</span>!</p>"
+      "<p>He<span style=\"font-weight: bold;\">ll</span><span style=\"text-decoration: underline;\">o Wo</span><span style=\"font-style: italic;\">rld</span>!</p>"
 
     assert to_html(input) == output
   end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -63,7 +63,7 @@ defmodule DraftTest do
   end
 
   test "wraps anchor entities" do
-    input = %{"entityMap"=>%{0=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
+    input = %{"entityMap"=>%{"0"=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
               "blocks"=>[%{"text"=>"Hello World!","inlineStyleRanges"=>[],"type"=>"unstyled","depth"=>0,"entityRanges"=>[
                             %{"offset"=>2,"length"=>3,"key"=>0}
                           ],"data"=>%{},"key"=>"9d21d"}]}
@@ -72,7 +72,7 @@ defmodule DraftTest do
   end
 
   test "wraps overlapping entities and inline styles" do
-    input = %{"entityMap"=>%{0=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
+    input = %{"entityMap"=>%{"0"=>%{"type"=>"LINK","mutability"=>"MUTABLE","data"=>%{"url"=>"http://google.com"}}},
               "blocks"=>[%{"text"=>"Hello World!",
                            "inlineStyleRanges"=>[
                              %{"style"=>"ITALIC","offset"=>0,"length"=>4},


### PR DESCRIPTION
https://trello.com/c/DXA1F6ab

Fixes a bug in Outlook that doesn’t respect an outer span’s styling on an inner a tag.